### PR TITLE
Add a `pip-audit` workflow

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,28 @@
+name: Scan dependencies for vulnerabilities with pip-audit
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Run pip-audit
+        uses: trailofbits/gh-action-pip-audit@v0.0.4
+        with:
+          inputs: requirements.txt
+


### PR DESCRIPTION
NFC. Uses `pip-audit` to scan the project's dependencies for known vulnerabilities.